### PR TITLE
Python 3 compatibility.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -560,9 +560,9 @@ def import_string(import_name, silent=False):
             modname = module + '.' + obj
             __import__(modname)
             return sys.modules[modname]
-    except ImportError, e:
+    except ImportError as e:
         if not silent:
-            raise ImportStringError(import_name, e), None, sys.exc_info()[2]
+            raise ImportStringError(import_name, e).with_traceback(sys.exc_info()[2])
 
 class ImportStringError(ImportError):
     """Provides information about a failed :func:`import_string` attempt.
@@ -621,7 +621,7 @@ def format_config(config, _lvl=0):
     return buf
 
 def print_config(config):
-    print format_config(config)
+    print(format_config(config))
 
 def obj_by_ref(o, path):
     for s in path.split("."):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = "0.5"
+version = "0.51"
 
 with open('README') as f:
     long_description = f.read()


### PR DESCRIPTION
Make the minimum modifications to get compatible with python 3 without losing python 2.7

I have not tested this, sorry.

python3.3 setup.py install
works (as does 2.7), but it turns out the package that I was trying to install, which imported configure, was supposed to import a different package named configure.  Therefore, I never ran the code after installing.

Test the changes before pushing.
