### PR TITLE
Implement Python 3 support, tested in both 2.7 and 3.5.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -4,7 +4,7 @@
     ===================================================
 
 """
-
+from __future__ import print_function
 import sys
 from os import path, mkdir
 from inspect import getargspec
@@ -163,7 +163,7 @@ class Configuration(MutableMapping):
                 self.__struct = self.__struct(
                     Configuration.from_dict({}, pwd=self._pwd))
 
-        for k, v in self.iteritems():
+        for k, v in self.items():
             self[k] = _impl(v)
 
         return self
@@ -560,9 +560,9 @@ def import_string(import_name, silent=False):
             modname = module + '.' + obj
             __import__(modname)
             return sys.modules[modname]
-    except ImportError, e:
+    except ImportError as e:
         if not silent:
-            raise ImportStringError(import_name, e), None, sys.exc_info()[2]
+            raise ImportStringError(import_name, e)
 
 class ImportStringError(ImportError):
     """Provides information about a failed :func:`import_string` attempt.
@@ -621,7 +621,7 @@ def format_config(config, _lvl=0):
     return buf
 
 def print_config(config):
-    print format_config(config)
+    print(format_config(config))
 
 def obj_by_ref(o, path):
     for s in path.split("."):

--- a/configure.py
+++ b/configure.py
@@ -562,7 +562,10 @@ def import_string(import_name, silent=False):
             return sys.modules[modname]
     except ImportError as e:
         if not silent:
-            raise ImportStringError(import_name, e)
+            if sys.version_info.major == 2:
+                exec("raise ImportStringError(import_name, e), None, sys.exc_info()[2]")  # Get around SyntaxError in Py3
+            else:
+                raise ImportStringError(import_name, e).with_traceback(sys.exc_info()[2])
 
 class ImportStringError(ImportError):
     """Provides information about a failed :func:`import_string` attempt.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = "0.5"
+version = "0.6"
 
 with open('README') as f:
     long_description = f.read()


### PR DESCRIPTION
I've tested my changes using the tests.py module and using it in my own Python3 code, this maintains backwards compatibility while also being Python 3 compatible. Read to merge.
